### PR TITLE
fixed wrong documentation RollingIndexName zone -> timeZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
         <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" zone="Europe/Warsaw" />
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
         ...
     </Elasticsearch>
 </Appenders>

--- a/log4j2-elasticsearch-core/README.md
+++ b/log4j2-elasticsearch-core/README.md
@@ -60,7 +60,7 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
         <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" zone="Europe/Warsaw" />
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
         ...
     </Elasticsearch>
 </Appenders>

--- a/log4j2-elasticsearch-jest/README.md
+++ b/log4j2-elasticsearch-jest/README.md
@@ -62,7 +62,7 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
         <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" zone="Europe/Warsaw" />
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
         ...
     </Elasticsearch>
 </Appenders>

--- a/log4j2-elasticsearch2-bulkprocessor/README.md
+++ b/log4j2-elasticsearch2-bulkprocessor/README.md
@@ -59,7 +59,7 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
         <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" zone="Europe/Warsaw" />
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
         ...
     </Elasticsearch>
 </Appenders>

--- a/log4j2-elasticsearch5-bulkprocessor/README.md
+++ b/log4j2-elasticsearch5-bulkprocessor/README.md
@@ -59,7 +59,7 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
         <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" zone="Europe/Warsaw" />
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
         ...
     </Elasticsearch>
 </Appenders>


### PR DESCRIPTION
@rfoltyns 
Fixed wrong documentation for RollingIndexNameFormatter attribute zone.  