### PR TITLE
Custom rolling index separator (#37)

### DIFF
--- a/log4j2-elasticsearch-core/README.md
+++ b/log4j2-elasticsearch-core/README.md
@@ -69,8 +69,8 @@ Since 1.1, rolling index can be defined using `RollingIndexName` tag:
 <Appenders>
     <Elasticsearch name="elasticsearchAsyncBatch">
         ...
-        <!-- zone is optional. OS timezone is used by default -->
-        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" />
+        <!-- zone is optional. OS timezone is used by default. separator is optional, - (hyphen, dash) is used by default. -->
+        <RollingIndexName indexName="log4j2" pattern="yyyy-MM-dd" timeZone="Europe/Warsaw" separator="." />
         ...
     </Elasticsearch>
 </Appenders>

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/RollingIndexNameFormatterTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/RollingIndexNameFormatterTest.java
@@ -152,6 +152,37 @@ public class RollingIndexNameFormatterTest {
         Assert.assertEquals("testIndexName-2017-12-20-22.54", formattedIndexName);
     }
 
+    @Test
+    public void returnsCustomSeparatorFormattedIndexName() {
+
+        // given
+        LogEvent logEvent = mock(LogEvent.class);
+        when(logEvent.getTimeMillis()).thenReturn(DEFAULT_TEST_TIME_IN_MILLIS);
+        RollingIndexNameFormatter.Builder builder = createRollingIndexNameFormatterBuilder();
+        builder.withSeparator(".");
+        IndexNameFormatter formatter = builder.build();
+
+        // when
+        String formattedIndexName = formatter.format(logEvent);
+
+        // then
+        Assert.assertEquals("testIndexName.2017-12-20-23.54", formattedIndexName);
+    }
+
+    @Test
+    public void returnsDefaultSeparatorFormattedIndexNameWithoutCustomSeparator() {
+
+        // given
+        LogEvent logEvent = mock(LogEvent.class);
+        when(logEvent.getTimeMillis()).thenReturn(DEFAULT_TEST_TIME_IN_MILLIS);
+        IndexNameFormatter formatter = new RollingIndexNameFormatter(TEST_INDEX_NAME, DATE_PATTERN_WITH_MINUTES, DEFAULT_TEST_TIME_IN_MILLIS, TEST_TIME_ZONE);
+
+        // when
+        String formattedIndexName = formatter.format(logEvent);
+
+        // then
+        Assert.assertEquals("testIndexName-2017-12-20-23.54", formattedIndexName);
+    }
 
     @Test
     public void returnsEventTimeBasedNameInsteadOfCurrentNameDuringRollover() throws InterruptedException {


### PR DESCRIPTION
Hello,
Currently the rolling index separator is hard coded as the hyphen "-" character.

Here is a PR to fix https://github.com/rfoltyns/log4j2-elasticsearch/issues/37

Cheers,
Cuneyt