### PR TITLE
Fix async dynamic virtual property resolving

### DIFF
--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/Log4j2Lookup.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/Log4j2Lookup.java
@@ -21,6 +21,7 @@ package org.appenders.log4j2.elasticsearch;
  */
 
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
+import org.apache.logging.log4j.core.LogEvent;
 
 public class Log4j2Lookup implements ValueResolver {
 
@@ -34,19 +35,20 @@ public class Log4j2Lookup implements ValueResolver {
      * Resolves given {@link VirtualProperty} if {@link VirtualProperty#isDynamic()} is true
      *
      * @param property property to resolve
+     * @param logEvent optional
      * @return resolved value
      */
     @Override
-    public String resolve(VirtualProperty property) {
+    public String resolve(VirtualProperty property, LogEvent logEvent) {
         if (property.isDynamic()) {
-            return resolve(property.getValue());
+            return resolve(property.getValue(), logEvent);
         }
         return property.getValue();
     }
 
     @Override
-    public String resolve(String unresolved) {
-        return strSubstitutor.replace(unresolved);
+    public String resolve(String unresolved, LogEvent logEvent) {
+        return strSubstitutor.replace(logEvent, unresolved);
     }
 
 }

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/NonEmptyFilter.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/NonEmptyFilter.java
@@ -22,13 +22,15 @@ package org.appenders.log4j2.elasticsearch;
 
 import static org.appenders.core.logging.InternalLogging.getLogger;
 
+import org.apache.logging.log4j.core.LogEvent;
+
 public class NonEmptyFilter implements VirtualPropertyFilter {
 
     /**
      * Allows to determine inclusion based on presence and length of given value.
      *
      * @param fieldName Name to be logged on exclusion
-     * @param resolvedValue result of {@link ValueResolver#resolve(VirtualProperty)}
+     * @param resolvedValue result of {@link ValueResolver#resolve(VirtualProperty, LogEvent)}
      *
      * @return <i>true</i>, if {@code resolvedValue} is not null and it's length is greater than 0, <i>false</i> otherwise
      */

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/ValueResolver.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/ValueResolver.java
@@ -20,24 +20,34 @@ package org.appenders.log4j2.elasticsearch;
  * #L%
  */
 
+import org.apache.logging.log4j.core.LogEvent;
+
 public interface ValueResolver {
 
     ValueResolver NO_OP = new ValueResolver() {
 
         @Override
-        public String resolve(String unresolved) {
+        public String resolve(String unresolved, LogEvent logEvent) {
             return unresolved;
         }
 
         @Override
-        public String resolve(VirtualProperty property) {
+        public String resolve(VirtualProperty property, LogEvent logEvent) {
             return property.getValue();
         }
 
     };
 
-    String resolve(String unresolved);
+    default String resolve(String unresolved) {
+        return resolve(unresolved, null);
+    }
 
-    String resolve(VirtualProperty property);
+    String resolve(String unresolved, LogEvent logEvent);
+
+    default String resolve(VirtualProperty property) {
+        return resolve(property, null);
+    }
+
+    String resolve(VirtualProperty property, LogEvent logEvent);
 
 }

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriter.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriter.java
@@ -20,6 +20,8 @@ package org.appenders.log4j2.elasticsearch;
  * #L%
  */
 
+import org.apache.logging.log4j.core.LogEvent;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.SerializationConfig;
@@ -112,7 +114,7 @@ public class VirtualPropertiesWriter extends VirtualBeanPropertyWriter {
 
             VirtualProperty property = virtualProperties[i];
 
-            String resolved = valueResolver.resolve(property);
+            String resolved = valueResolver.resolve(property, (bean instanceof LogEvent) ? (LogEvent) bean : null);
             if (isExcluded(property, resolved)) {
                 continue;
             }

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertyFilter.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertyFilter.java
@@ -20,13 +20,15 @@ package org.appenders.log4j2.elasticsearch;
  * #L%
  */
 
+import org.apache.logging.log4j.core.LogEvent;
+
 public interface VirtualPropertyFilter {
 
     /**
      * Allows to determine inclusion based on given field name and/or value
      *
      * @param fieldName {@link VirtualProperty#getName()}
-     * @param value result of {@link ValueResolver#resolve(VirtualProperty)}
+     * @param value result of {@link ValueResolver#resolve(VirtualProperty, LogEvent)}
      *
      * @return <i>true</i>, if {@link VirtualProperty} should be included by {@link VirtualPropertiesWriter}, <i>false</i> otherwise
      */

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/Log4j2LookupTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/Log4j2LookupTest.java
@@ -20,6 +20,8 @@ package org.appenders.log4j2.elasticsearch;
  * #L%
  */
 
+
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.junit.jupiter.api.Test;
@@ -29,11 +31,12 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class Log4j2LookupTest {
 
@@ -63,19 +66,16 @@ public class Log4j2LookupTest {
 
         StrSubstitutor strSubstitutor = spy(createDefaultTestStrSubstitutor());
         Log4j2Lookup lookup = createDefaultTestLog4j2Lookup(strSubstitutor);
+        LogEvent event1 = mock(LogEvent.class);
+        LogEvent event2 = mock(LogEvent.class);
 
         // when
-        lookup.resolve(virtualProperty);
-        lookup.resolve(virtualProperty);
+        lookup.resolve(virtualProperty, event1);
+        lookup.resolve(virtualProperty, event2);
 
         // then
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-
-        verify(strSubstitutor, times(2)).replace(captor.capture());
-
-        assertEquals(expectedValue, captor.getAllValues().get(0));
-        assertEquals(expectedValue, captor.getAllValues().get(1));
-
+        verify(strSubstitutor).replace(event1, expectedValue);
+        verify(strSubstitutor).replace(event2, expectedValue);
     }
 
     @Test
@@ -91,12 +91,12 @@ public class Log4j2LookupTest {
         Log4j2Lookup lookup = spy(createDefaultTestLog4j2Lookup(createDefaultTestStrSubstitutor()));
 
         // when
-        lookup.resolve(virtualProperty);
+        lookup.resolve(virtualProperty, null);
 
         // then
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
-        verify(lookup, times(1)).resolve(captor.capture());
+        verify(lookup, times(1)).resolve(captor.capture(), any());
 
         assertEquals(expectedValue, captor.getValue());
 
@@ -117,7 +117,7 @@ public class Log4j2LookupTest {
         lookup.resolve(virtualProperty);
 
         // then
-        verify(strSubstitutor, never()).replace(anyString());
+        verifyNoInteractions(strSubstitutor);
 
     }
 

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriterTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriterTest.java
@@ -166,7 +166,7 @@ public class VirtualPropertiesWriterTest {
         writer.serializeAsField(new Object(), mock(JsonGenerator.class), mock(SerializerProvider.class));
 
         // then
-        verify(valueResolver).resolve(eq(virtualProperty));
+        verify(valueResolver).resolve(virtualProperty, null);
 
     }
 
@@ -284,7 +284,7 @@ public class VirtualPropertiesWriterTest {
 
     private ValueResolver createTestValueResolver(VirtualProperty virtualProperty, String expectedValue) {
         ValueResolver valueResolver = mock(ValueResolver.class);
-        when(valueResolver.resolve(virtualProperty)).thenReturn(expectedValue);
+        when(valueResolver.resolve(virtualProperty, null)).thenReturn(expectedValue);
         return valueResolver;
     }
 

--- a/log4j2-elasticsearch-hc/src/test/java/org/appenders/log4j2/elasticsearch/hc/HCHttpPluginTest.java
+++ b/log4j2-elasticsearch-hc/src/test/java/org/appenders/log4j2/elasticsearch/hc/HCHttpPluginTest.java
@@ -133,7 +133,7 @@ public class HCHttpPluginTest {
         // given
         Configuration configuration = mock(Configuration.class);
         StrSubstitutor strSubstitutor = mock(StrSubstitutor.class);
-        when(strSubstitutor.replace((String)any())).thenReturn(UUID.randomUUID().toString());
+        when(strSubstitutor.replace(eq(null), (String)any())).thenReturn(UUID.randomUUID().toString());
 
         when(configuration.getStrSubstitutor()).thenReturn(strSubstitutor);
 
@@ -154,7 +154,7 @@ public class HCHttpPluginTest {
         factory.setupOperationFactory().create(indexTemplate);
 
         // then
-        verify(strSubstitutor).replace(eq(expectedSource));
+        verify(strSubstitutor).replace(null, expectedSource);
 
     }
 

--- a/log4j2-elasticsearch-jest/src/test/java/org/appenders/log4j2/elasticsearch/jest/JestHttpObjectFactoryTest.java
+++ b/log4j2-elasticsearch-jest/src/test/java/org/appenders/log4j2/elasticsearch/jest/JestHttpObjectFactoryTest.java
@@ -235,7 +235,7 @@ public class JestHttpObjectFactoryTest {
         // given
         Configuration configuration = mock(Configuration.class);
         StrSubstitutor strSubstitutor = mock(StrSubstitutor.class);
-        when(strSubstitutor.replace((String)any())).thenReturn(UUID.randomUUID().toString());
+        when(strSubstitutor.replace(eq(null), (String)any())).thenReturn(UUID.randomUUID().toString());
 
         when(configuration.getStrSubstitutor()).thenReturn(strSubstitutor);
 
@@ -257,7 +257,7 @@ public class JestHttpObjectFactoryTest {
 
         // then
         assertTrue(factory.valueResolver() instanceof Log4j2Lookup);
-        verify(strSubstitutor).replace(eq(expectedSource));
+        verify(strSubstitutor).replace(null, expectedSource);
 
     }
 

--- a/log4j2-elasticsearch2-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
+++ b/log4j2-elasticsearch2-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
@@ -356,7 +356,7 @@ public class BulkProcessorObjectFactoryTest {
         // given
         Configuration configuration = mock(Configuration.class);
         StrSubstitutor strSubstitutor = mock(StrSubstitutor.class);
-        when(strSubstitutor.replace((String)any())).thenReturn(UUID.randomUUID().toString());
+        when(strSubstitutor.replace(eq(null), (String)any())).thenReturn(UUID.randomUUID().toString());
 
         when(configuration.getStrSubstitutor()).thenReturn(strSubstitutor);
 
@@ -378,7 +378,7 @@ public class BulkProcessorObjectFactoryTest {
 
         // then
         verify(configuration).getStrSubstitutor();
-        verify(strSubstitutor).replace(eq(expectedSource));
+        verify(strSubstitutor).replace(eq(null), eq(expectedSource));
 
     }
 

--- a/log4j2-elasticsearch5-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
+++ b/log4j2-elasticsearch5-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
@@ -335,7 +335,7 @@ public class BulkProcessorObjectFactoryTest {
         // given
         Configuration configuration = mock(Configuration.class);
         StrSubstitutor strSubstitutor = mock(StrSubstitutor.class);
-        when(strSubstitutor.replace((String)any())).thenReturn(UUID.randomUUID().toString());
+        when(strSubstitutor.replace(eq(null), (String)any())).thenReturn(UUID.randomUUID().toString());
 
         when(configuration.getStrSubstitutor()).thenReturn(strSubstitutor);
 
@@ -357,7 +357,7 @@ public class BulkProcessorObjectFactoryTest {
 
         // then
         verify(configuration).getStrSubstitutor();
-        verify(strSubstitutor).replace(eq(expectedSource));
+        verify(strSubstitutor).replace(null, expectedSource);
 
     }
 

--- a/log4j2-elasticsearch6-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
+++ b/log4j2-elasticsearch6-bulkprocessor/src/test/java/org/appenders/log4j2/elasticsearch/bulkprocessor/BulkProcessorObjectFactoryTest.java
@@ -336,7 +336,7 @@ public class BulkProcessorObjectFactoryTest {
         // given
         Configuration configuration = mock(Configuration.class);
         StrSubstitutor strSubstitutor = mock(StrSubstitutor.class);
-        when(strSubstitutor.replace((String)any())).thenReturn(UUID.randomUUID().toString());
+        when(strSubstitutor.replace(eq(null), (String)any())).thenReturn(UUID.randomUUID().toString());
 
         when(configuration.getStrSubstitutor()).thenReturn(strSubstitutor);
 
@@ -358,7 +358,7 @@ public class BulkProcessorObjectFactoryTest {
 
         // then
         verify(configuration).getStrSubstitutor();
-        verify(strSubstitutor).replace(eq(expectedSource));
+        verify(strSubstitutor).replace(null, expectedSource);
 
     }
 


### PR DESCRIPTION
When using an async appender, the event formatter will be called in a different thread than the one where the logger was called. Hence the current thread context is different when resolving virtual properties than when the event is created. To carry over the thread context to the other thread, the async appender creates a copy of the log event which creates a copy of the thread context and attaches it to the new log event. To resolve thread context properties`org.apache.logging.log4j.core.lookup.StrSubstitutor.replace(LogEvent, String)` needs to be called with the log event.

However, virtual properties were being resolved via `org.apache.logging.log4j.core.lookup.StrSubstitutor.replace(String)` and hence thread context properties were not usable in virtual properties and always came out unresolved. See e.g. in `ContextMapLookup`

```java
    public String lookup(final String key) {
        return currentContextData().getValue(key);
    }
```

vs

```java
    public String lookup(final LogEvent event, final String key) {
        return event.getContextData().getValue(key);
    }
```

The first commit only contains a (broken) unit test which recreates the issue. The second commit fixes the issue. I was unsure about some things and put comments in the pull request.