### PR TITLE
Allow configuring any VirtualBeanPropertyWriter

### DIFF
--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/JacksonHandlerInstantiator.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/JacksonHandlerInstantiator.java
@@ -89,6 +89,10 @@ public class JacksonHandlerInstantiator extends HandlerInstantiator {
      */
     @Override
     public VirtualPropertiesWriter virtualPropertyWriterInstance(MapperConfig<?> config, Class<?> implClass) {
+        if (implClass != VirtualPropertiesWriter.class) {
+            // Jackson will instantiate the class if null is returned
+            return null;
+        }
         if (instance == null) {
             instance = new VirtualPropertiesWriter(
                     virtualProperties,

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/JacksonHandlerInstantiatorTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/JacksonHandlerInstantiatorTest.java
@@ -77,6 +77,24 @@ public class JacksonHandlerInstantiatorTest {
     }
 
     @Test
+    public void virtualPropertyWriterInstanceReturnsNullForUnrelatedTypes() {
+
+        // given
+        VirtualProperty[] customProperties = new VirtualProperty[0];
+        ValueResolver valueResolver = Mockito.mock(ValueResolver.class);
+        JacksonHandlerInstantiator handlerInstantiator = createTestHandlerInstantiator(customProperties, valueResolver);
+
+        MapperConfig config = new ObjectMapper().getSerializationConfig();
+
+        // when
+        VirtualPropertiesWriter instance = handlerInstantiator.virtualPropertyWriterInstance(config, VirtualBeanPropertyWriter.class);
+
+        // then
+        assertNull(instance);
+
+    }
+
+    @Test
     public void deserializerInstanceReturnsNull() {
 
         // given


### PR DESCRIPTION
When using mixin annotated with `@JsonAppend(props = { @Prop(name = "some_prop", value = SomeReturnType.class, type = ExtendsVirtualBeanPropertyWriter.class) })`, `JacksonHandlerInstantiator` returned its `VirtualPropertiesWriter` instance for `ExtendsVirtualBeanPropertyWriter` breaking the annotation.