### PR TITLE
Add option to serialize VirtualProperty as JSON object

### DIFF
--- a/log4j2-elasticsearch-core/README.md
+++ b/log4j2-elasticsearch-core/README.md
@@ -315,8 +315,21 @@ Config property | Type | Required | Default | Description
 name | Attribute | yes | n/a |
 value | Attribute | yes | n/a | Static value or contextual variable resolvable with <a href="https://logging.apache.org/log4j/2.x/manual/lookups.html">Log4j2 Lookups</a>.
 dynamic | Attribute | no | false | if `true`, indicates that value may change over time and should be resolved on every serialization (see [Log4j2Lookup](https://github.com/rfoltyns/log4j2-elasticsearch/blob/master/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/Log4j2Lookup.java)). Otherwise, will be resolved only on startup.
+writeRaw (since 1.6) | Attribute | no | false | indicates that the value is a valid, structured object (e.g JSON string) and should be written as such.
+
+Since 1.6, one can put a valid, structured object (e.g. a JSON string) into a VirtualProperty's value, set `writeRaw` to `true` and it will be written without quotes when serialized.
+
+###### Example:
+
+```xml
+<NonEmptyFilter/>
+<VirtualProperty name="jsonStringField" 
+	value="$${ctx:myJsonObject:-}" 
+	dynamic="true" writeRaw="true"/>
+```
 
 Custom lookup can implemented with [ValueResolver](https://github.com/rfoltyns/log4j2-elasticsearch/blob/master/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/ValueResolver.java).
+
 
 ##### Virtual Property Filters
 
@@ -329,6 +342,7 @@ Available filters:
 Custom filtering can be implemented with [`VirtualPropertyFilter`](https://github.com/rfoltyns/log4j2-elasticsearch/blob/master/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertyFilter.java).
 
 Example:
+
 ```xml
 <Elasticsearch name="elasticsearchAsyncBatch">
     ...

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriter.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriter.java
@@ -118,7 +118,11 @@ public class VirtualPropertiesWriter extends VirtualBeanPropertyWriter {
             }
 
             gen.writeFieldName(property.getName());
-            gen.writeString(resolved);
+            if (property.isWriteRaw()) {
+                gen.writeRawValue(resolved);
+            } else {
+                gen.writeString(resolved);
+            }
 
         }
     }

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualProperty.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualProperty.java
@@ -29,6 +29,7 @@ public class VirtualProperty {
     private final String name;
     private String value;
     private final boolean dynamic;
+    private final boolean writeRaw;
 
     /**
      * @param name Name
@@ -36,9 +37,20 @@ public class VirtualProperty {
      * @param isDynamic In case of resolvable properties, this flag indicates that resolved value may change over time
      */
     public VirtualProperty(final String name, final String value, final boolean isDynamic) {
+        this(name, value, isDynamic, false);
+    }
+
+    /**
+     * @param name Name
+     * @param value May be static or in a any format resolvable by configured {@link ValueResolver}
+     * @param isDynamic In case of resolvable properties, this flag indicates that resolved value may change over time
+     * @param writeRaw Indicates that the value is a valid, structured object (e.g JSON string) and should be written as such.
+     */
+    public VirtualProperty(final String name, final String value, final boolean isDynamic, boolean writeRaw) {
         this.name = name;
         this.value = value;
         this.dynamic = isDynamic;
+        this.writeRaw = writeRaw;
     }
 
     public String getName() {
@@ -62,6 +74,10 @@ public class VirtualProperty {
         return dynamic;
     }
 
+    public boolean isWriteRaw() {
+        return writeRaw;
+    }
+
     @Override
     public String toString() {
         return String.format("%s=%s", name, value);
@@ -72,12 +88,13 @@ public class VirtualProperty {
         private String name;
         private String value;
         private boolean dynamic;
+        private boolean writeRaw;
 
         public VirtualProperty build() {
 
             validate();
 
-            return new VirtualProperty(name, value, dynamic);
+            return new VirtualProperty(name, value, dynamic, writeRaw);
 
         }
 
@@ -108,6 +125,10 @@ public class VirtualProperty {
             return this;
         }
 
+        public Builder withWriteRaw(boolean writeRaw) {
+            this.writeRaw = writeRaw;
+            return this;
+        }
     }
 
 }

--- a/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertyPlugin.java
+++ b/log4j2-elasticsearch-core/src/main/java/org/appenders/log4j2/elasticsearch/VirtualPropertyPlugin.java
@@ -41,9 +41,10 @@ public class VirtualPropertyPlugin extends VirtualProperty {
      * @param name Name
      * @param value May be static or in a resolvable format defined by <a href="https://logging.apache.org/log4j/2.x/manual/lookups.html">Log4j2 Lookups</a>
      * @param isDynamic In case of resolvable properties, this flag indicates that resolved value may change over time
+     * @param writeRaw Indicates that the value is a valid, structured object (e.g JSON string) and should be written as such.
      */
-    public VirtualPropertyPlugin(final String name, final String value, final boolean isDynamic) {
-        super(name, value, isDynamic);
+    public VirtualPropertyPlugin(final String name, final String value, final boolean isDynamic, final boolean writeRaw) {
+        super(name, value, isDynamic, writeRaw);
     }
 
     @PluginBuilderFactory
@@ -62,19 +63,24 @@ public class VirtualPropertyPlugin extends VirtualProperty {
         @PluginBuilderAttribute
         private boolean dynamic;
 
+        @PluginBuilderAttribute
+        private boolean writeRaw;
+
         @Override
         public VirtualPropertyPlugin build() {
 
             final VirtualProperty.Builder builder = new VirtualProperty.Builder()
                     .withName(name)
                     .withValue(value)
-                    .withDynamic(dynamic);
+                    .withDynamic(dynamic)
+                    .withWriteRaw(writeRaw);
 
             try {
                 final VirtualProperty virtualProperty = builder.build();
                 return new VirtualPropertyPlugin(virtualProperty.getName(),
                         virtualProperty.getValue(),
-                        virtualProperty.isDynamic());
+                        virtualProperty.isDynamic(),
+                        virtualProperty.isWriteRaw());
             } catch (Exception e) {
                 throw new ConfigurationException(e);
             }
@@ -96,6 +102,10 @@ public class VirtualPropertyPlugin extends VirtualProperty {
             return this;
         }
 
+        public Builder withWriteRaw(boolean writeRaw) {
+            this.writeRaw = writeRaw;
+            return this;
+        }
     }
 
 }

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriterTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertiesWriterTest.java
@@ -203,6 +203,31 @@ public class VirtualPropertiesWriterTest {
     }
 
     @Test
+    public void serializeAsFieldWritesGivenPropertiesAsRawValuesIfConfigured() throws Exception {
+
+        // given
+        String expectedName = UUID.randomUUID().toString();
+        String expectedValue = "{\"value\":1}";
+
+        VirtualProperty jsonVirtualProperty = createNonDynamicRawVirtualProperty(expectedName, expectedValue);
+
+        VirtualPropertiesWriter writer = new VirtualPropertiesWriter(
+                new VirtualProperty[] { jsonVirtualProperty },
+                ValueResolver.NO_OP
+        );
+
+        JsonGenerator jsonGenerator = mock(JsonGenerator.class);
+
+        // when
+        writer.serializeAsField(new Object(), jsonGenerator, mock(SerializerProvider.class));
+
+        // then
+        verify(jsonGenerator).writeFieldName(eq(expectedName));
+        verify(jsonGenerator).writeRawValue(eq(expectedValue));
+
+    }
+
+    @Test
     public void serializeAsFieldDoesNotWritePropertiesIfNoPropertiesProvided() throws Exception {
 
         // given
@@ -301,6 +326,21 @@ public class VirtualPropertiesWriterTest {
         }
 
         return builder.withDynamic(false).build();
+    }
+
+    private VirtualProperty createNonDynamicRawVirtualProperty(String expectedName, String expectedValue) {
+
+        VirtualProperty.Builder builder = createDefaultVirtualPropertyBuilder();
+
+        if (expectedName != null) {
+            builder.withName(expectedName);
+        }
+
+        if (expectedValue != null) {
+            builder.withValue(expectedValue);
+        }
+
+        return builder.withDynamic(false).withWriteRaw(true).build();
     }
 
     private VirtualPropertyFilter createNonExcludingTestVirtualPropertyFilter(String expectedName, String expectedValue) {

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertyPluginTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertyPluginTest.java
@@ -112,6 +112,21 @@ public class VirtualPropertyPluginTest {
     }
 
     @Test
+    public void builderSetsWriteRaw() {
+
+        // given
+        VirtualPropertyPlugin.Builder builder = createDefaultVirtualPropertyBuilder()
+                .withWriteRaw(true);
+
+        // when
+        VirtualProperty property = builder.build();
+
+        // then
+        assertTrue(property.isWriteRaw());
+
+    }
+
+    @Test
     public void valueCanBeOverridenAfterCreation() {
 
         // given

--- a/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertyTest.java
+++ b/log4j2-elasticsearch-core/src/test/java/org/appenders/log4j2/elasticsearch/VirtualPropertyTest.java
@@ -111,6 +111,21 @@ public class VirtualPropertyTest {
     }
 
     @Test
+    public void builderSetsWriteRaw() {
+
+        // given
+        VirtualProperty.Builder builder = createDefaultVirtualPropertyBuilder()
+                .withWriteRaw(true);
+
+        // when
+        VirtualProperty property = builder.build();
+
+        // then
+        assertTrue(property.isWriteRaw());
+
+    }
+
+    @Test
     public void valueCanBeOverridenAfterCreation() {
 
         // given
@@ -151,7 +166,8 @@ public class VirtualPropertyTest {
         return new VirtualProperty.Builder()
                 .withName(UUID.randomUUID().toString())
                 .withValue(UUID.randomUUID().toString())
-                .withDynamic(false);
+                .withDynamic(false)
+                .withWriteRaw(false);
     }
 
 }


### PR DESCRIPTION
In some cases it would be very useful if one could put a JSON object into i.e. a `CloseableThreadContext` (which only accepts strings) and have it serialized as JSON when submitted to ElasticSearch. This PR adds a new attribute to `VirtualProperty` which enables just this.